### PR TITLE
Compatibility with the KernelBrowser client used by the symfony2 mink driver.

### DIFF
--- a/src/Zitec/ApiZitecExtension/Context/RestContext.php
+++ b/src/Zitec/ApiZitecExtension/Context/RestContext.php
@@ -5,6 +5,7 @@ namespace Zitec\ApiZitecExtension\Context;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\MinkContext;
+use Exception;
 use Symfony\Component\BrowserKit\Client;
 use Zitec\ApiZitecExtension\Data\Data;
 use Zitec\ApiZitecExtension\Data\LoadData;
@@ -174,6 +175,8 @@ class RestContext extends MinkContext implements RestAwareContext
      * @Given I load data from file :file
      *
      * @param string $file
+     *
+     * @throws Exception
      */
     public function iLoadDataFromFile($file)
     {
@@ -253,6 +256,8 @@ class RestContext extends MinkContext implements RestAwareContext
      *
      * @param string $queryString
      * @param string|null $dataSet
+     *
+     * @throws Exception
      */
     public function iRequest($queryString, $dataSet = null)
     {
@@ -280,18 +285,18 @@ class RestContext extends MinkContext implements RestAwareContext
      * @Given /^the response is (JSON|XML|empty)$/
      *
      * @param string $responseType
-     * @throws \Exception
+     * @throws Exception
      */
     public function checkResponseType($responseType)
     {
         if (!isset($this->response)) {
-            throw new \Exception("There is no response set yet.");
+            throw new Exception("There is no response set yet.");
         }
         $responseType = strtolower($responseType);
         switch ($responseType) {
             case 'empty':
                 if ($this->response->getContent() !== null) {
-                    throw new \Exception(
+                    throw new Exception(
                         sprintf(
                             "The content of the response is not empty!\n%s",
                             $this->response->getContent()->getRawContent()
@@ -301,10 +306,10 @@ class RestContext extends MinkContext implements RestAwareContext
                 break;
             default:
                 if (!$this->response->contentTypeIs($responseType)) {
-                    throw new \Exception(sprintf('The response is not %s', $responseType));
+                    throw new Exception(sprintf('The response is not %s', $responseType));
                 }
                 if ($this->response->getContent() === null) {
-                    throw new \Exception(sprintf('The response is empty'));
+                    throw new Exception(sprintf('The response is empty'));
                 }
                 break;
         }
@@ -312,6 +317,8 @@ class RestContext extends MinkContext implements RestAwareContext
 
     /**
      * @Then /^I extract access token from the response$/
+     * 
+     * @throws Exception
      */
     public function extractAccessTokenFromResponse()
     {
@@ -319,7 +326,7 @@ class RestContext extends MinkContext implements RestAwareContext
         if (!empty($authParams)) {
             if (isset($authParams['auth_type']) && $authParams['auth_type'] === 'token') {
                 if (!isset($authParams['token']) || !isset($authParams['secret'])) {
-                    throw new \Exception(
+                    throw new Exception(
                         '"token" and "secret" authentication parameters must be set for token authentication type.'
                     );
                 }
@@ -337,7 +344,7 @@ class RestContext extends MinkContext implements RestAwareContext
 
     /**
      * @param string|null $dataSet
-     * @throws \Exception
+     * @throws Exception
      *
      * @Given /^the response match the expected response(?:| from "([^"]*)" dataset)$/
      */
@@ -347,13 +354,13 @@ class RestContext extends MinkContext implements RestAwareContext
         if (isset($this->response)) {
             $this->compare->matchResponse($expectedResponse, $this->response);
         } else {
-            throw new \Exception("The response is not set yet.");
+            throw new Exception("The response is not set yet.");
         }
     }
 
     /**
      * @param string|null $dataSet
-     * @throws \Exception
+     * @throws Exception
      *
      * @Then /^the response match the expected structure(?:| from "([^"]*)" dataset)$/
      * @Then /^each response from the collection match the expected structure(?:| from "([^"]*)" dataset)$/
@@ -364,7 +371,7 @@ class RestContext extends MinkContext implements RestAwareContext
         if (isset($this->response)) {
             $this->compare->matchStructure($expectedResponse, $this->response);
         } else {
-            throw new \Exception("The response is not set yet.");
+            throw new Exception("The response is not set yet.");
         }
     }
 
@@ -373,19 +380,19 @@ class RestContext extends MinkContext implements RestAwareContext
      *
      * @param string $responseKey
      * @param string $name
-     * @throws \Exception
+     * @throws Exception
      *
      * @Given /^I save the "([^"]*)" as "([^"]*)"$/
      */
     public function iSaveTheAs($responseKey, $name)
     {
         if (!isset($this->response)) {
-            throw new \Exception('The response is not set yet.');
+            throw new Exception('The response is not set yet.');
         }
 
         $value = $this->response->getContent()->getItem($responseKey);
         if (!isset($value)) {
-            throw new \Exception('The given key was not found in the response.');
+            throw new Exception('The given key was not found in the response.');
         }
         $this->storage->storeValue($name, $value);
     }
@@ -410,8 +417,8 @@ class RestContext extends MinkContext implements RestAwareContext
 
     /**
      * Set the request parameter in url from the saved response under key $name
-     * In case of multiple parameters in url the response keys will be fund in the TableNode
-     * The request should look like this: /method/%d
+     * In case of multiple parameters in url the response keys will be fund in
+     * the TableNode The request should look like this: /method/%d
      *
      * @param string $request
      * @param string | TableNode $name
@@ -421,6 +428,8 @@ class RestContext extends MinkContext implements RestAwareContext
      * @When I request :request using :varKey
      * @When I request :request with dataset :dataSet using:
      * @When I request :request using:
+     *
+     * @throws \Exception
      */
     public function iRequestUsingWithDataset($request, $name, $dataSet = null)
     {
@@ -442,27 +451,27 @@ class RestContext extends MinkContext implements RestAwareContext
      *  Makes a request on the path given in the location header and checks the response status code.
      *
      * @param int $status
-     * @throws \Exception
+     * @throws Exception
      *
      * @Then I check location header to return :status
      */
     public function checkLocationHeader($status)
     {
         if (!isset($this->response)) {
-            throw new \Exception('The response is not set yet.');
+            throw new Exception('The response is not set yet.');
         }
 
         $locationHeader = $this->response->getHeader('Location');
 
         if (!isset($locationHeader)) {
-            throw new \Exception('No Location header received.');
+            throw new Exception('No Location header received.');
         }
 
         $this->iRequest($locationHeader);
         try {
             $this->assertResponseStatus($status);
-        } catch (\Exception $exception) {
-            throw new \Exception(
+        } catch (Exception $exception) {
+            throw new Exception(
                 'The response status code after request on the Location header invalid. '
                 . $exception->getMessage()
             );
@@ -474,6 +483,8 @@ class RestContext extends MinkContext implements RestAwareContext
      *
      * @param string $queryString
      * @param  $data
+     *
+     * @throws Exception
      */
     protected function doHttpRequest($queryString, $data)
     {
@@ -497,16 +508,19 @@ class RestContext extends MinkContext implements RestAwareContext
             }
         }
 
+        $serverParams = $this->getReformattedHeaderNames($headers);
+
         $baseUrl = $this->getMinkParameter('base_url');
-        $this->request->setHeaders($headers, $this->parameters->getSeenheaders());
-        $this->request->request($baseUrl, $queryString, $this->parameters->getRequestMethod(), $data);
+        $this->request->request($baseUrl, $queryString, $this->parameters->getRequestMethod(), $data, $serverParams);
     }
 
     /**
      * @param $type
      * @param $params
      * @param $queryString
+     *
      * @return AbstractAlgorithm
+     * @throws Exception
      */
     protected function getAuth($type, $params, $queryString)
     {
@@ -520,5 +534,27 @@ class RestContext extends MinkContext implements RestAwareContext
         );
 
         return $auth;
+    }
+
+    /**
+     * Prefix the header names as needed by the browser-kit client.
+     *
+     * @param array $headers
+     *
+     * @return array
+     */
+    protected function getReformattedHeaderNames($headers)
+    {
+        $contentHeaders = array('content_length' => true, 'content_md5' => true, 'content_type' => true);
+
+        $reformattedHeaders = [];
+        foreach ($headers as $headerName => $value) {
+            if (!isset($contentHeaders[$headerName])) {
+                $headerName = 'HTTP_'.$headerName;
+            }
+            $reformattedHeaders[$headerName] = $value;
+        }
+
+        return $reformattedHeaders;
     }
 }

--- a/src/Zitec/ApiZitecExtension/Data/Parameters.php
+++ b/src/Zitec/ApiZitecExtension/Data/Parameters.php
@@ -73,7 +73,6 @@ class Parameters
      */
     public function addHeader($name, $value)
     {
-        $this->seenHeaders[] = $name;
         $this->headers[$name] = $value;
     }
 
@@ -125,14 +124,6 @@ class Parameters
         foreach ($headers as $name => $value) {
             $this->addHeader($name, $value);
         }
-    }
-
-    /**
-     * @return array
-     */
-    public function getSeenHeaders()
-    {
-        return array_unique($this->seenHeaders);
     }
 
     /**

--- a/src/Zitec/ApiZitecExtension/Services/Request.php
+++ b/src/Zitec/ApiZitecExtension/Services/Request.php
@@ -2,7 +2,7 @@
 
 namespace Zitec\ApiZitecExtension\Services;
 
-use Goutte\Client;
+use Symfony\Component\BrowserKit\Client;
 
 /**
  * Class Request
@@ -12,10 +12,11 @@ use Goutte\Client;
  */
 class Request
 {
-    /**
-     * @var Client
-     */
+    /** @var Client */
     protected $client;
+
+    /** @var array */
+    protected $headers;
 
     /**
      * Request constructor.
@@ -25,22 +26,7 @@ class Request
     public function __construct(Client $client)
     {
         $this->client = $client;
-    }
-
-    /**
-     * Cleans up the existing headers and sets the new ones.
-     *
-     * @param array $headers
-     * @param array $seenHeaders
-     */
-    public function setHeaders($headers, $seenHeaders)
-    {
-        foreach ($seenHeaders as $sHeader) {
-            $this->client->removeHeader($sHeader);
-        }
-        foreach ($headers as $name => $value) {
-            $this->client->setHeader($name, $value);
-        }
+        $this->headers = [];
     }
 
     /**
@@ -48,8 +34,9 @@ class Request
      * @param string $queryString
      * @param string $requestMethod
      * @param array $data
+     * @param array $serverParams
      */
-    public function request($baseUrl, $queryString, $requestMethod, array $data)
+    public function request($baseUrl, $queryString, $requestMethod, array $data, array $serverParams = [])
     {
         if (!empty($data['get'])) {
             $queryString = $queryString . '?' . http_build_query($data['get'], null, '&',
@@ -61,7 +48,7 @@ class Request
 
         $files = isset($data['files']) ? $data['files'] : [];
 
-        $this->client->request($requestMethod, $uri, $data[$httpVerb], $files);
+        $this->client->request($requestMethod, $uri, $data[$httpVerb], $files, $serverParams);
     }
 
     /**

--- a/src/Zitec/ApiZitecExtension/Services/Response/Response.php
+++ b/src/Zitec/ApiZitecExtension/Services/Response/Response.php
@@ -32,13 +32,12 @@ class Response
      *
      * @param string $content
      * @param array $headers
-     * @throws \Exception
      */
     public function __construct($content, $headers)
     {
 
         foreach ($headers as $key => $header) {
-            $this->headers[$key] = reset($header);
+            $this->headers[strtolower($key)] = reset($header);
         }
         if (strlen($content) === 0) {
             return;
@@ -60,6 +59,7 @@ class Response
      */
     public function getHeader($name)
     {
+        $name = strtolower($name);
         if (isset($this->headers[$name])) {
             return $this->headers[$name];
         }

--- a/src/Zitec/ApiZitecExtension/Services/Response/Response.php
+++ b/src/Zitec/ApiZitecExtension/Services/Response/Response.php
@@ -37,7 +37,7 @@ class Response
     {
 
         foreach ($headers as $key => $header) {
-            $this->headers[strtolower($key)] = reset($header);
+            $this->headers[$key] = reset($header);
         }
         if (strlen($content) === 0) {
             return;
@@ -60,8 +60,10 @@ class Response
     public function getHeader($name)
     {
         $name = strtolower($name);
-        if (isset($this->headers[$name])) {
-            return $this->headers[$name];
+        foreach ($this->headers as $key => $header) {
+            if (strtolower($key) === $name) {
+                return $header;
+            }
         }
 
         return null;

--- a/tests/Zitec/ApiZitecExtension/Context/InputData.php
+++ b/tests/Zitec/ApiZitecExtension/Context/InputData.php
@@ -6,6 +6,36 @@ namespace Tests\Zitec\ApiZitecExtension\Context;
 /**
  * Class InputData
  *
+ * @property-read $http_method
+ * @property-read $data_file_name
+ * @property-read $headers
+ * @property-read $auth
+ * @property-read $headers_to_remove
+ * @property-read $added_request_time
+ * @property-read $data_for_request
+ * @property-read $data_set
+ * @property-read $empty_response_type
+ * @property-read $json_response_type
+ * @property-read $auth_params
+ * @property-read $auth_no_secret
+ * @property-read $auth_no_token
+ * @property-read $response_data
+ * @property-read $index_to_save
+ * @property-read $value_to_save
+ * @property-read $name_to_save
+ * @property-read $stored_key
+ * @property-read $dataSetKey
+ * @property-read $stored_value
+ * @property-read $request_with_placeholder
+ * @property-read $request_url
+ * @property-read $response_key
+ * @property-read $table_column
+ * @property-read $location_header
+ * @property-read $headers_token
+ * @property-read $auth_data
+ * @property-read $complete_auth_headers
+ * @property-read $base_url
+ *
  * @author Bianca VADEAN bianca.vadean@zitec.com
  * @copyright Copyright (c) Zitec COM
  */

--- a/tests/Zitec/ApiZitecExtension/Context/RestContextTest.php
+++ b/tests/Zitec/ApiZitecExtension/Context/RestContextTest.php
@@ -1320,17 +1320,6 @@ class RestContextTest extends TestCase
             ->with('base_url')
             ->willReturn($baseUrl);
 
-        $seenHeaders = $inputData->headers_token;
-
-        $this->parameters->expects($this->once())
-            ->method('getSeenHeaders')
-            ->willReturn($seenHeaders);
-        $completeHeaders = $inputData->complete_auth_headers;
-
-        $request->expects($this->once())
-            ->method('setHeaders')
-            ->with($completeHeaders, $seenHeaders);
-
         $data = [];
         $requestMethod = $inputData->request_method;
         $request->expects($this->once())
@@ -1376,14 +1365,6 @@ class RestContextTest extends TestCase
             ->method('getMinkParameter')
             ->with('base_url')
             ->willReturn($baseUrl);
-
-        $this->parameters->expects($this->once())
-            ->method('getSeenHeaders')
-            ->willReturn($headers);
-
-        $request->expects($this->once())
-            ->method('setHeaders')
-            ->with($headers, $headers);
 
         $data = [];
         $queryString = '/';


### PR DESCRIPTION
Type-hint the abstract browser-kit client.
Send headers as the server parameters argument in the request call, and properly reformat header names.
When checking content-type header, use lowercase header name.

Fixed code style warnings from the IDE.